### PR TITLE
Fix deployment branch targets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: DEPLOY
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -3,7 +3,7 @@ name: DEPLOY (test)
 on:
   push:
     branches-ignore:
-      - master
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
Deploymnet definitions were originally focused on "master" branch, but "master" branch is not a thing in this repo.